### PR TITLE
Update README and AppFooter for improved footer content and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,22 @@ Beyond syntax colors, Caligo includes intent-based highlighting:
 - [**Contributing**](CONTRIBUTING.md) — Development setup & guidelines
 - [**Quick Start**](QUICKSTART.md) — Developer quick start guide
 
-## 📄 License
+<br>
 
-[MIT](LICENSE) © [Anselm Hahn](https://github.com/Anselmoo)
-
----
-
-<p align="center">
-  <sub>Built with 🌙 for developers who code after dark</sub>
-</p>
+<div align="center">
+  <hr>
+  <br>
+  <p>
+    &copy; 2026 Anselm Hahn. MIT Licensed.
+  </p>
+  <p>
+    Built with ❤️ for developers who code after dark 🌙
+  </p>
+  <p>
+    <a href="https://marketplace.visualstudio.com/items?itemName=AnselmHahn.caligo-vscode-theme">Marketplace</a> •
+    <a href="https://github.com/Anselmoo/caligo-vscode-theme">GitHub</a> •
+    <a href="https://anselmoo.github.io/caligo-vscode-theme/#/gallery">Gallery</a> •
+    <a href="CONTRIBUTING.md">Contributing</a> •
+    <a href="LICENSE">License</a>
+  </p>
+</div>

--- a/src/vue-app/components/layout/AppFooter.vue
+++ b/src/vue-app/components/layout/AppFooter.vue
@@ -11,8 +11,7 @@ const currentYear = new Date().getFullYear();
             &copy; {{ currentYear }} Anselm Hahn. MIT Licensed.
           </p>
           <p class="footer-tagline">
-            <i class="pi pi-moon"></i>
-            Built with <i class="pi pi-heart-fill"></i> for developers who code after dark
+            Built with <i class="pi pi-heart-fill"></i> for developers who code after dark <i class="pi pi-moon"></i>
           </p>
         </div>
         <div class="footer-links">


### PR DESCRIPTION
This pull request updates the project’s footer and README to improve branding, copyright information, and link presentation. The changes modernize the license section, clarify the copyright year, and enhance the tagline for a more professional and welcoming appearance.

Branding and copyright improvements:

* Updated the license and copyright section in `README.md` to use a centered layout, include the correct copyright year, and present links to the Marketplace, GitHub, Gallery, Contributing, and License pages.
* Modified the tagline in `AppFooter.vue` to place the moon icon after the phrase, improving readability and branding consistency.

Closes #5 