### PR TITLE
Fix git reference in deployment steps

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -602,6 +602,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
       - name: Mark workspace as a safe git directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Ensure the correct git reference is used during deployment steps to improve the reliability of the workflow. This change enhances the accuracy of the deployment process by referencing the appropriate git context.

